### PR TITLE
Added option to create missing folders

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ gulp.task('lint', function() {
   return gulp.src('./lib/*.js')
     .pipe(jshint())
     .pipe(jshint.reporter('gulp-jshint-html-reporter', {
-      filename: __dirname + '/jshint-output.html'
+      filename: __dirname + '/jshint-output.html',
+      createMissingFolders : false  
     }));
 });
 ```
@@ -32,6 +33,12 @@ Type: `filename`
 Default: `"jshint-output.html"`
 
 The filename to write output from jshint. When linting is successfull, the file is not created.
+
+Type: `createMissingFolders`
+Default: `false`
+
+Enables or disables creation of any folders given in the filename that do not exist. 
+If disabled and the given path contains folders which do not exist, an ENOENT error is thrown. 
 
 ## License
 

--- a/reporter.js
+++ b/reporter.js
@@ -108,6 +108,16 @@ module.exports = {
                 .replace('{summary}', prepareSummary());
         }
 
+        fs.mkdirTree = function (dir){
+            var parent = path.dirname(dir);
+            if(!fs.existsSync(parent)){
+                fs.mkdirTree(parent);
+            }
+            if (!fs.existsSync(dir)) {
+                fs.mkdir(dir);
+            }
+        }              
+
         function writeToFile(content, opts) {
             opts = opts || {};
             opts.filename = opts.filename || defaultFilename;
@@ -116,12 +126,14 @@ module.exports = {
                 wrStream.end();
                 wrStream = null;
             }
-
             if (!wrStream) {
+                var dir = path.dirname(opts.filename);
+                if (opts.createMissingFolders && !fs.existsSync(dir)) {
+                    fs.mkdirTree(dir);
+                }
                 wrStream = fs.createWriteStream(opts.filename);
                 filename = opts.filename;
             }
-
             wrStream.write(content);
         }
 


### PR DESCRIPTION
I noticed during usage of this plugin that if given a file path which contains one or more non existent parent folders, the plugin would fail and throw an ENOENT error.

This is undesirable for me, as I prefer to generate logs of each gulp build consisting of any created reports contained within timestamped folders. This would fail with the plugin as those folders don't necessarily exist when the report is ready to be written. Therefore I did the following to amend this:

Added option to enable or disable the creation of any missing folders in
the given file path. See updated README for details on usage.