### PR TITLE
Always use HTTPS for Bootstrap CDN

### DIFF
--- a/templates/bootstrap/body.html
+++ b/templates/bootstrap/body.html
@@ -3,7 +3,7 @@
 <head>
     <title>JSHint Report</title>
     <meta charset="{charset}">
-    <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css">
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css">
 </head>
 <body>
 


### PR DESCRIPTION
I have found that even though in the template it has the style sheet URL like this `//maxcdn.bootstrapcdn.com`, it always renders like this `http://maxcdn.bootstrapcdn.com`. That causes it to be styleless when hosted somewhere with HTTPS. So I have changed it to be hard coded to HTTPS. There isn't a good reason (that I am aware of) for not using HTTPS anyway. 